### PR TITLE
Add client command /alwaysRenderPlayerNametags 

### DIFF
--- a/src/generated/resources/assets/ltextras/lang/en_ud.json
+++ b/src/generated/resources/assets/ltextras/lang/en_ud.json
@@ -115,6 +115,7 @@
   "block.ltextras.white_glow_sticks": "sʞɔıʇS ʍoן⅁ ǝʇıɥM",
   "block.ltextras.yellow_glow_sticks": "sʞɔıʇS ʍoן⅁ ʍoןןǝʎ",
   "chat.ltextras.message_translated": "˙ʇɟǝן ǝɥʇ oʇ ɹɐq ǝʇıɥʍ ǝɥʇ ɹǝʌo buıɹǝʌoɥ ʎq ǝbɐssǝɯ ןɐuıbıɹo ǝɥʇ ǝǝs uɐɔ noʎ ˙ǝʇɐɹnɔɔɐ ǝq ʇou ʎɐɯ ʇı puɐ 'pǝʇɐןsuɐɹʇ-ǝuıɥɔɐɯ uǝǝq sɐɥ ǝbɐssǝɯ ʇɐɥɔ sıɥ⟘",
+  "commands.nametag.success": "%s :sbɐʇǝɯɐu ɹǝpuǝɹ sʎɐʍןⱯ",
   "commands.tpa.general_error": "ʇɹodǝןǝʇ oʇ ǝןqɐu∩",
   "commands.tpa.help.back": "buıʇɹodǝןǝʇ ǝɹoɟǝq ǝɹǝʍ noʎ ǝɹǝɥʍ oʇ ʞɔɐq ʇɹodǝןǝ⟘ - ʞɔɐq/",
   "commands.tpa.help.tpa": "ɹǝʎɐןd ɐ oʇ ʇɹodǝןǝʇ oʇ ʇsǝnbǝᴚ - >ɹǝʎɐןd< ɐdʇ/",

--- a/src/generated/resources/assets/ltextras/lang/en_us.json
+++ b/src/generated/resources/assets/ltextras/lang/en_us.json
@@ -115,6 +115,7 @@
   "block.ltextras.white_glow_sticks": "White Glow Sticks",
   "block.ltextras.yellow_glow_sticks": "Yellow Glow Sticks",
   "chat.ltextras.message_translated": "This chat message has been machine-translated, and it may not be accurate. You can see the original message by hovering over the white bar to the left.",
+  "commands.nametag.success": "Always render nametags: %s",
   "commands.tpa.general_error": "Unable to teleport",
   "commands.tpa.help.back": "/back - Teleport back to where you were before teleporting",
   "commands.tpa.help.tpa": "/tpa <player> - Request to teleport to a player",

--- a/src/main/java/com/lovetropics/extras/LTExtras.java
+++ b/src/main/java/com/lovetropics/extras/LTExtras.java
@@ -1,5 +1,6 @@
 package com.lovetropics.extras;
 
+import com.lovetropics.extras.client.command.RenderPlayerNameTagCommand;
 import com.lovetropics.extras.client.particle.ExtraParticles;
 import com.lovetropics.extras.collectible.CollectibleCommand;
 import com.lovetropics.extras.collectible.CollectibleStore;
@@ -24,6 +25,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.ForgeConfigSpec;
@@ -82,6 +84,7 @@ public class LTExtras {
 		});
 
 		MinecraftForge.EVENT_BUS.addListener(this::onRegisterCommands);
+		MinecraftForge.EVENT_BUS.addListener(this::onRegisterClientCommands);
 
 		ExtraLangKeys.init(registrate());
 		registrate()
@@ -96,6 +99,7 @@ public class LTExtras {
 
 					TpCommand.addTranslations(p);
 					WarpCommand.addTranslations(p);
+					RenderPlayerNameTagCommand.addTranslations(p);
                 })
                 .generic(TAB_ID.getPath(), Registries.CREATIVE_MODE_TAB, () -> CreativeModeTab.builder()
                         .title(registrate().addLang("itemGroup", TAB_ID, "LTExtras"))
@@ -147,6 +151,11 @@ public class LTExtras {
 		WorldEffectCommand.register(dispatcher);
 		WarpCommand.register(dispatcher);
 		PoiCommand.register(dispatcher);
+	}
+
+	private void onRegisterClientCommands(RegisterClientCommandsEvent event) {
+		CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+		RenderPlayerNameTagCommand.register(dispatcher);
 	}
 
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/lovetropics/extras/client/command/RenderPlayerNameTagCommand.java
+++ b/src/main/java/com/lovetropics/extras/client/command/RenderPlayerNameTagCommand.java
@@ -10,6 +10,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderNameTagEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -17,7 +18,7 @@ import net.minecraftforge.fml.common.Mod;
 import static com.mojang.brigadier.arguments.BoolArgumentType.bool;
 import static net.minecraft.commands.Commands.literal;
 
-@Mod.EventBusSubscriber(modid = LTExtras.MODID)
+@Mod.EventBusSubscriber(modid = LTExtras.MODID, value = Dist .CLIENT)
 public class RenderPlayerNameTagCommand {
     private static boolean alwaysRenderNameTags = false;
 

--- a/src/main/java/com/lovetropics/extras/client/command/RenderPlayerNameTagCommand.java
+++ b/src/main/java/com/lovetropics/extras/client/command/RenderPlayerNameTagCommand.java
@@ -1,0 +1,57 @@
+package com.lovetropics.extras.client.command;
+
+import com.lovetropics.extras.LTExtras;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.tterrag.registrate.providers.RegistrateLangProvider;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.client.event.RenderNameTagEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import static com.mojang.brigadier.arguments.BoolArgumentType.bool;
+import static net.minecraft.commands.Commands.literal;
+
+@Mod.EventBusSubscriber(modid = LTExtras.MODID)
+public class RenderPlayerNameTagCommand {
+    private static boolean alwaysRenderNameTags = false;
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(literal("alwaysRenderPlayerNametags")
+                .executes(RenderPlayerNameTagCommand::toggleAlwaysRender)
+                .then(Commands.argument("state", bool())
+                        .executes(RenderPlayerNameTagCommand::setAlwaysRender)
+                ));
+    }
+
+    public static int toggleAlwaysRender(final CommandContext<CommandSourceStack> ctx) {
+        setSend(ctx, !alwaysRenderNameTags);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    public static int setAlwaysRender(final CommandContext<CommandSourceStack> ctx) {
+        setSend(ctx, BoolArgumentType.getBool(ctx, "state"));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static void setSend(final CommandContext<CommandSourceStack> ctx, final boolean newValue) {
+        alwaysRenderNameTags = newValue;
+        ctx.getSource().sendSuccess(() -> Component.translatable("commands.nametag.success", alwaysRenderNameTags), false);
+    }
+
+    @SubscribeEvent
+    public static void onRenderNameTagEvent(RenderNameTagEvent evt) {
+        if (alwaysRenderNameTags && evt.getEntity() instanceof Player) {
+            evt.setResult(RenderNameTagEvent.Result.ALLOW);
+        }
+    }
+
+    public static void addTranslations(final RegistrateLangProvider provider) {
+        provider.add("commands.nametag.success", "Always render nametags: %s");
+    }
+}


### PR DESCRIPTION
* The command `/alwaysRenderPlayerNametags [true/false]` doesn't exactly roll off the tongue - suggestions?
* It's not super clever and will show tags through walls and stuff


But I guesssss it fulfills its purpose?